### PR TITLE
Sample tk data

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ An overview of the methodology, coloured by the three main steps to the pipeline
 
 More details of the steps included in this project, and running instructions, can be found in their respective READMEs:
 
-1. [sentence_classifier](skills_taxonomy_v2/pipeline/sentence_classifier/README.md) - Training a classifier to predict skill sentences.
-2. [skills_extraction](skills_taxonomy_v2/pipeline/skills_extraction/README.md) - Extracting skills from skill sentences.
-3. [skills_taxonomy](skills_taxonomy_v2/pipeline/skills_taxonomy/README.md) - Building the skills taxonomy from extracted skills.
+1. [tk_data_analysis](skills_taxonomy_v2/pipeline/tk_data_analysis/README.md) - Get a sample of the TextKernel job adverts.
+2. [sentence_classifier](skills_taxonomy_v2/pipeline/sentence_classifier/README.md) - Training a classifier to predict skill sentences.
+3. [skills_extraction](skills_taxonomy_v2/pipeline/skills_extraction/README.md) - Extracting skills from skill sentences.
+4. [skills_taxonomy](skills_taxonomy_v2/pipeline/skills_taxonomy/README.md) - Building the skills taxonomy from extracted skills.
 
 ### Analysis
 

--- a/skills_taxonomy_v2/analysis/tk_analysis/TextKernel Sample - 25th Oct 2021.py
+++ b/skills_taxonomy_v2/analysis/tk_analysis/TextKernel Sample - 25th Oct 2021.py
@@ -1,0 +1,139 @@
+# ---
+# jupyter:
+#   jupytext:
+#     cell_metadata_filter: -all
+#     comment_magics: true
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.4
+#   kernelspec:
+#     display_name: Python 3 (ipykernel)
+#     language: python
+#     name: python3
+# ---
+
+# %% [markdown]
+# ## Examining the sample of textkernel data used from the extension work from 25th October 2021.
+#
+# - Not all the job ids have dates given in the date metadata (it may not even be a key, or may have a value of None).
+# i.e. there are 62892486 job adverts, but only 50566709 keys in the dates metadata
+#
+#
+
+# %%
+from skills_taxonomy_v2.getters.s3_data import (
+    load_s3_data,
+    get_s3_data_paths,
+    save_to_s3,
+)
+
+from collections import Counter, defaultdict
+import random
+import os
+
+from datetime import datetime
+from tqdm import tqdm
+import pandas as pd
+import boto3
+import matplotlib.pyplot as plt
+
+bucket_name = "skills-taxonomy-v2"
+s3 = boto3.resource("s3")
+
+# %% [markdown]
+# ### All the TK data with dates
+
+# %%
+tk_dates = {}
+for file_name in tqdm(range(0, 13)):
+    file_date_dict = load_s3_data(
+        s3, bucket_name, f"outputs/tk_data_analysis/metadata_date/{file_name}.json"
+    )
+    tk_dates.update({k: f[0] for k, f in file_date_dict.items()})
+
+print(len(tk_dates))
+
+# %%
+job_ads_date_count = defaultdict(int)
+
+for k, v in tqdm(tk_dates.items()):
+    if v:
+        date = v[0:7]
+        job_ads_date_count[date] += 1
+    else:
+        job_ads_date_count["No date given"] += 1
+
+# %%
+sum(job_ads_date_count.values()) == total_n_job_adverts
+
+# %% [markdown]
+# ### Dates for the sample
+
+# %%
+sample_dict = load_s3_data(
+    s3, bucket_name, "outputs/tk_sample_data/sample_file_locations.json"
+)
+
+# %%
+sample_dict["historical/2020/2020-03-11/jobs_0.0.jsonl.gz"][0:10]
+
+# %%
+sum([len(v) for v in sample_dict.values()])
+
+# %%
+job_ads_date_count_sample = defaultdict(int)
+for job_id_list in tqdm(sample_dict.values()):
+    for job_id in job_id_list:
+        v = tk_dates.get(job_id)
+        if v:
+            date = v[0:7]
+            job_ads_date_count_sample[date] += 1
+        else:
+            job_ads_date_count_sample["No date given"] += 1
+
+# %%
+sum(job_ads_date_count_sample.values())
+
+
+# %% [markdown]
+# ### Plot proportions together
+
+# %%
+def find_num_dates(count_dict):
+    num_dates = {
+        int(k.split("-")[0]) + int(k.split("-")[1]) / 12: v
+        for k, v in count_dict.items()
+        if k != "No date given"
+    }
+    num_dates[2014] = count_dict["No date given"]
+    return num_dates
+
+
+# %%
+num_dates = find_num_dates(job_ads_date_count)
+num_dates_sample = find_num_dates(job_ads_date_count_sample)
+
+# %%
+plt.figure(figsize=(10, 4))
+plt.bar(
+    num_dates.keys(),
+    [v / sum(num_dates.values()) for v in num_dates.values()],
+    width=0.1,
+    alpha=0.5,
+    label="All data",
+)
+plt.bar(
+    num_dates_sample.keys(),
+    [v / sum(num_dates_sample.values()) for v in num_dates_sample.values()],
+    width=0.1,
+    color="red",
+    alpha=0.5,
+    label="Sample of data",
+)
+plt.legend()
+plt.xlabel("Date of job advert (2014 = no date given)")
+plt.ylabel("Proportion")
+
+# %%

--- a/skills_taxonomy_v2/config/predict_skill_sentences/2021.10.26.yaml
+++ b/skills_taxonomy_v2/config/predict_skill_sentences/2021.10.26.yaml
@@ -1,0 +1,9 @@
+flows:
+  predict_skill_sentences_flow:
+    params:
+      input_dir: "inputs/data/"
+      data_dir: "textkernel-files/"
+      model_config_name: "2021.08.16"
+      output_dir: "outputs/sentence_classifier/data/skill_sentences"
+      sampled_data_loc: "outputs/tk_sample_data/sample_file_locations.json"
+    run_id: 0

--- a/skills_taxonomy_v2/config/predict_skill_sentences/2021.10.27.yaml
+++ b/skills_taxonomy_v2/config/predict_skill_sentences/2021.10.27.yaml
@@ -1,0 +1,9 @@
+flows:
+  predict_skill_sentences_flow:
+    params:
+      input_dir: "inputs/data/"
+      data_dir: "textkernel-files/"
+      model_config_name: "2021.08.16"
+      output_dir: "outputs/sentence_classifier/data/skill_sentences"
+      sampled_data_loc: "outputs/tk_sample_data/sample_file_locations.json"
+    run_id: 0

--- a/skills_taxonomy_v2/config/tk_data_sample/2021.10.25.yaml
+++ b/skills_taxonomy_v2/config/tk_data_sample/2021.10.25.yaml
@@ -1,0 +1,7 @@
+flows:
+  get_tk_sample:
+    params:
+      tk_metadata_dir: "outputs/tk_data_analysis/metadata_file/"
+      sample_size: 5000000
+      random_seed: 42
+      output_dir: "outputs/tk_sample_data/"

--- a/skills_taxonomy_v2/pipeline/sentence_classifier/README.md
+++ b/skills_taxonomy_v2/pipeline/sentence_classifier/README.md
@@ -225,11 +225,19 @@ with the most recent config file will take in job adverts, split them into sente
 {'job_id_1': [('sentence1'), ('sentence2')], 'job_id_2': [('sentence1'), ('sentence2'}
 ```
 
-To predict on all job adverts in the TextKernel data on S3, on the EC2 instance I ran
+### `2021.10.27.yaml` config file:
+
+When using the `2021.10.27.yaml` config file skill sentences are predicted on a pre-determined sample of 5 million job adverts (found via running `get_tk_sample.py`). This was run using:
 
 ```
-python skills_taxonomy_v2/pipeline/sentence_classifier/predict_sentence_class.py --config_path 'skills_taxonomy_v2/config/predict_skill_sentences/2021.08.16.yaml'
+python skills_taxonomy_v2/pipeline/sentence_classifier/predict_sentence_class.py --config_path 'skills_taxonomy_v2/config/predict_skill_sentences/2021.10.27.yaml'
 ```
+
+Skill sentences for each job advert and file are stored in `outputs/sentence_classifier/data/skill_sentences/2021.10.27/`.
+
+Out of the 647 files of job adverts, 516 had skill sentences in. This is because the 'jobs_expired' files were included in the sample and these don't contain the job advert text. This leaves us with a sample of 4,312,285 job adverts.
+
+
 
 ### From `2021.07.09.yaml`:
 

--- a/skills_taxonomy_v2/pipeline/sentence_classifier/predict_sentence_class.py
+++ b/skills_taxonomy_v2/pipeline/sentence_classifier/predict_sentence_class.py
@@ -342,7 +342,7 @@ def run_predict_sentence_class_presample(
     in get_tk_sample.py and save out for every relevant file in the dir.
     """
 
-    sent_classifier, _ = load_model(model_config_name, multi_process=True, batch_size=64)
+    sent_classifier, _ = load_model(model_config_name, multi_process=True, batch_size=32)
     nlp = spacy.load("en_core_web_sm")
 
     s3 = boto3.resource("s3")

--- a/skills_taxonomy_v2/pipeline/sentence_classifier/predict_sentence_class.py
+++ b/skills_taxonomy_v2/pipeline/sentence_classifier/predict_sentence_class.py
@@ -41,6 +41,7 @@ from skills_taxonomy_v2.pipeline.sentence_classifier.utils import split_sentence
 
 from skills_taxonomy_v2 import PROJECT_DIR, BUCKET_NAME
 
+from skills_taxonomy_v2.getters.s3_data import load_s3_data, save_to_s3
 
 logger = logging.getLogger(__name__)
 
@@ -68,7 +69,7 @@ def load_local_data(file_name):
     return data
 
 
-def load_s3_data(file_name, s3):
+def load_s3_text_data(file_name, s3):
     """
     Load from S3 locations - jsonl.gz
     file_name: S3 key
@@ -248,7 +249,7 @@ def run_predict_sentence_class(
         if data_local:
             data = load_local_data(data_path)
         else:
-            data = load_s3_data(data_path, s3)
+            data = load_s3_text_data(data_path, s3)
 
         data = data[0:10000]
         if data:
@@ -329,12 +330,124 @@ def run_predict_sentence_class(
                     save_outputs_to_s3(s3, skill_sentences_dict, output_file_dir)
 
 
+def run_predict_sentence_class_presample(
+    input_dir, data_dir, model_config_name, output_dir, sampled_data_loc
+):
+    """
+    Get predictions from the sample of job adverts already found
+    in get_tk_sample.py and save out for every relevant file in the dir.
+    """
+
+    sent_classifier, _ = load_model(model_config_name)
+    nlp = spacy.load("en_core_web_sm")
+
+    s3 = boto3.resource("s3")
+
+    sample_dict = load_s3_data(s3, BUCKET_NAME, sampled_data_loc)
+
+    # Make predictions and save output for data path(s)
+    logger.info(f"Running predictions on {len(sample_dict)} data files ...")
+    for data_subpath, job_ids in sample_dict.items():
+        # Run predictions and save outputs iteratively
+        data_path = os.path.join(input_dir, data_dir, data_subpath)
+        logger.info(f"Loading data from {data_path} ...")
+        data = load_s3_data(s3, BUCKET_NAME, data_path)
+
+        job_ids_set = set(job_ids)
+
+        # Sample of job adverts used for this file
+        neccessary_fields = ["full_text", "job_id"]
+        data = [
+            {field: job_ad.get(field, None) for field in neccessary_fields}
+            for job_ad in data
+            if job_ad["job_id"] in job_ids_set
+        ]
+
+        # CHANGE ==========================================!!!!!!!!!!!!
+        data = data[0:10]
+
+        if data:
+            output_file_dir = get_output_name(
+                data_path, input_dir, output_dir, model_config_name
+            )
+
+            logger.info(f"Splitting sentences ...")
+            start_time = time.time()
+            with Pool(4) as pool:  # 4 cpus
+                partial_split_sentence = partial(split_sentence, nlp=nlp, min_length=30)
+                split_sentence_pool_output = pool.map(partial_split_sentence, data)
+            logger.info(f"Splitting sentences took {time.time() - start_time} seconds")
+
+            # Process output into one list of sentences for all documents
+            sentences = []
+            job_ids = []
+            for i, (job_id, s) in enumerate(split_sentence_pool_output):
+                if s:
+                    sentences += s
+                    job_ids += [job_id] * len(s)
+
+            logger.info(f"Processing sentences took {time.time() - start_time} seconds")
+
+            if sentences:
+                logger.info(f"Transforming skill sentences ...")
+                sentences_vec = sent_classifier.transform(sentences)
+                pool_sentences_vec = [
+                    (vec_ix, [vec]) for vec_ix, vec in enumerate(sentences_vec)
+                ]
+
+                logger.info(f"Chunking up sentences ...")
+                start_time = time.time()
+                # Manually chunk up the data to predict multiple in a pool
+                # This is because predict can't deal with massive vectors
+                pool_sentences_vecs = []
+                pool_sentences_vec = []
+                for vec_ix, vec in enumerate(sentences_vec):
+                    pool_sentences_vec.append((vec_ix, vec))
+                    if len(pool_sentences_vec) > 1000:
+                        pool_sentences_vecs.append(pool_sentences_vec)
+                        pool_sentences_vec = []
+                if len(pool_sentences_vec) != 0:
+                    # Add the final chunk if not empty
+                    pool_sentences_vecs.append(pool_sentences_vec)
+                logger.info(
+                    f"Chunking up sentences into {len(pool_sentences_vecs)} chunks took {time.time() - start_time} seconds"
+                )
+
+                logger.info(f"Predicting skill sentences ...")
+                start_time = time.time()
+                with Pool(4) as pool:  # 4 cpus
+                    partial_predict_sentences = partial(
+                        predict_sentences, sent_classifier=sent_classifier
+                    )
+                    predict_sentences_pool_output = pool.map(
+                        partial_predict_sentences, pool_sentences_vecs
+                    )
+                logger.info(
+                    f"Predicting on {len(sentences)} sentences took {time.time() - start_time} seconds"
+                )
+
+                # Process output into one list of sentences for all documents
+                logger.info(f"Combining data for output ...")
+                start_time = time.time()
+                skill_sentences_dict = defaultdict(list)
+                for chunk_output in predict_sentences_pool_output:
+                    for (sent_ix, pred) in chunk_output:
+                        if pred == 1:
+                            job_id = job_ids[sent_ix]
+                            sentence = sentences[sent_ix]
+                            skill_sentences_dict[job_id].append(sentence)
+                logger.info(f"Combining output took {time.time() - start_time} seconds")
+
+                logger.info(f"Saving data to {output_file_dir} ...")
+                save_to_s3(s3, BUCKET_NAME, skill_sentences_dict, output_file_dir)
+
+
 def parse_arguments(parser):
 
     parser.add_argument(
         "--config_path",
         help="Path to config file",
-        default="skills_taxonomy_v2/config/predict_skill_sentences/2021.08.16.local.sample.yaml",
+        default="skills_taxonomy_v2/config/predict_skill_sentences/2021.10.26.yaml",
     )
 
     args, unknown = parser.parse_known_args()
@@ -355,29 +468,47 @@ if __name__ == "__main__":
     flow_config = config["flows"][FLOW_ID]
     params = flow_config["params"]
 
-    if not params["sample_data_paths"]:
-        # If you don't want to sample the data you can set these to None
-        params["random_seed"] = None
-        params["sample_size"] = None
-
-    # Output data in a subfolder with the name of the model used to make the predictions
-    if params["data_local"]:
-        input_dir = os.path.join(PROJECT_DIR, params["input_dir"])
-        output_dir = os.path.join(
-            PROJECT_DIR, params["output_dir"], params["model_config_name"]
+    if params.get("sampled_data_loc"):
+        # >=26th October 2021 configs should have this
+        # where job advert sampling has already been done
+        # Previously the outputs were stored in a folder with the
+        # model version, now store in the config version.
+        run_predict_sentence_class_presample(
+            params["input_dir"],
+            params["data_dir"],
+            params["model_config_name"],
+            os.path.join(
+                params["output_dir"],
+                os.path.basename(args.config_path).split(".yaml")[0],
+            ),
+            params["sampled_data_loc"],
         )
-    else:
-        # If we are pulling the data from S3 we don't want the paths to join with our local project_dir
-        input_dir = params["input_dir"]
-        output_dir = os.path.join(params["output_dir"], params["model_config_name"])
 
-    run_predict_sentence_class(
-        input_dir,
-        params["data_dir"],
-        params["model_config_name"],
-        output_dir,
-        data_local=params["data_local"],
-        sample_data_paths=params["sample_data_paths"],
-        random_seed=params["random_seed"],
-        sample_size=params["sample_size"],
-    )
+    else:
+        # Old version
+        if not params.get("sample_data_paths"):
+            # If you don't want to sample the data you can set these to None
+            params["random_seed"] = None
+            params["sample_size"] = None
+
+        # Output data in a subfolder with the name of the model used to make the predictions
+        if params["data_local"]:
+            input_dir = os.path.join(PROJECT_DIR, params["input_dir"])
+            output_dir = os.path.join(
+                PROJECT_DIR, params["output_dir"], params["model_config_name"]
+            )
+        else:
+            # If we are pulling the data from S3 we don't want the paths to join with our local project_dir
+            input_dir = params["input_dir"]
+            output_dir = os.path.join(params["output_dir"], params["model_config_name"])
+
+        run_predict_sentence_class(
+            input_dir,
+            params["data_dir"],
+            params["model_config_name"],
+            output_dir,
+            data_local=params["data_local"],
+            sample_data_paths=params["sample_data_paths"],
+            random_seed=params["random_seed"],
+            sample_size=params["sample_size"],
+        )

--- a/skills_taxonomy_v2/pipeline/sentence_classifier/predict_sentence_class.py
+++ b/skills_taxonomy_v2/pipeline/sentence_classifier/predict_sentence_class.py
@@ -363,9 +363,6 @@ def run_predict_sentence_class_presample(
             if job_ad["job_id"] in job_ids_set
         ]
 
-        # CHANGE ==========================================!!!!!!!!!!!!
-        data = data[0:10]
-
         if data:
             output_file_dir = get_output_name(
                 data_path, input_dir, output_dir, model_config_name

--- a/skills_taxonomy_v2/pipeline/sentence_classifier/sentence_classifier.py
+++ b/skills_taxonomy_v2/pipeline/sentence_classifier/sentence_classifier.py
@@ -64,9 +64,11 @@ class BertVectorizer:
         self,
         bert_model_name="sentence-transformers/paraphrase-MiniLM-L6-v2",
         multi_process=True,
+        batch_size=32
     ):
         self.bert_model_name = bert_model_name
         self.multi_process = multi_process
+        self.batch_size = batch_size
 
     def fit(self, *_):
         self.bert_model = SentenceTransformer(self.bert_model_name)
@@ -79,7 +81,7 @@ class BertVectorizer:
         if self.multi_process:
             print(".. with multiprocessing")
             pool = self.bert_model.start_multi_process_pool()
-            self.embedded_x = self.bert_model.encode_multi_process(texts, pool)
+            self.embedded_x = self.bert_model.encode_multi_process(texts, pool, batch_size=self.batch_size)
             self.bert_model.stop_multi_process_pool(pool)
         else:
             self.embedded_x = self.bert_model.encode(texts, show_progress_bar=True)
@@ -126,6 +128,7 @@ class SentenceClassifier:
         test_size=0.15,
         bert_model_name="sentence-transformers/paraphrase-MiniLM-L6-v2",
         multi_process=True,
+        batch_size=32,
         max_depth=7,
         min_child_weight=1,
         gamma=0.0,
@@ -144,6 +147,7 @@ class SentenceClassifier:
         self.bert_model_name = bert_model_name
         self.bert_model_name = bert_model_name
         self.multi_process = multi_process
+        self.batch_size = batch_size
         self.max_depth = max_depth
         self.min_child_weight = min_child_weight
         self.gamma = gamma
@@ -195,7 +199,9 @@ class SentenceClassifier:
 
     def load_bert(self):
         self.bert_vectorizer = BertVectorizer(
-            bert_model_name=self.bert_model_name, multi_process=self.multi_process
+            bert_model_name=self.bert_model_name,
+            multi_process=self.multi_process,
+            batch_size=self.batch_size
         )
         self.bert_vectorizer.fit()
 

--- a/skills_taxonomy_v2/pipeline/sentence_classifier/utils.py
+++ b/skills_taxonomy_v2/pipeline/sentence_classifier/utils.py
@@ -17,7 +17,7 @@ import numpy as np
 import os
 import boto3
 from s3fs.core import S3FileSystem
-from functools import lru_cache
+from functools import lru_cache, partial
 
 import nltk
 
@@ -47,7 +47,7 @@ def text_cleaning(text):
     return text.lower()
 
 
-def split_sentence(data, nlp, min_length=30):
+def split_sentence(data, min_length=30):
     """
     Split and clean one sentence.
     Output is two lists, a list of each sentence and a list of the job_ids they are from.
@@ -60,15 +60,22 @@ def split_sentence(data, nlp, min_length=30):
         sentences = []
         job_id = data.get("job_id")
         # Split up sentences
-        doc = nlp(text)
-        for sent in doc.sents:
-            sentence = text_cleaning(sent.text)
+        sents = nltk.sent_tokenize(text)
+        for sent in sents:
+            sentence = text_cleaning(sent)
             if len(sentence) > min_length:
                 sentences.append(sentence)
         return job_id, sentences
     else:
         return None, None
 
+def split_sentence_over_chunk(chunk, min_length):
+    partial_split_sentence = partial(split_sentence, min_length=min_length)
+    return list(map(partial_split_sentence, chunk))
+
+def make_chunks(lst, n):
+    for i in range(0, len(lst), n):
+        yield lst[i:i + n]
 
 @lru_cache(maxsize=None)
 def load_training_data_from_s3(prefix="final_training_data"):

--- a/skills_taxonomy_v2/pipeline/tk_data_analysis/README.md
+++ b/skills_taxonomy_v2/pipeline/tk_data_analysis/README.md
@@ -1,0 +1,17 @@
+# TK data sample
+
+In the first step of finding a skills taxonomy from job adverts we take a sample of the job advert data.
+
+This can be done by running:
+
+```
+python skills_taxonomy_v2/pipeline/tk_data_analysis/get_tk_sample.py --config_path skills_taxonomy_v2/config/tk_data_sample/2021.10.25.yaml
+```
+
+## `2021.10.25.yaml` config file
+
+This samples 5,000,000 job adverts randomly from all the TextKernel files. This sample was further reduced to 4,312,285 job adverts since some of the sample included job adverts which don't have the full text field available.
+
+The output is a dict of each TextKernel file name and a list of the job ids within it which are included in the sample. e.g. `{"historical/...0.json": ['6001f8701aeb4072a8eb0cca85535208', ...]}`. This then provides an easy way to open the original file and get the text from each of the job adverts included in the sample.
+
+This output is saved in `outputs/tk_sample_data/sample_file_locations.json`.

--- a/skills_taxonomy_v2/pipeline/tk_data_analysis/get_tk_sample.py
+++ b/skills_taxonomy_v2/pipeline/tk_data_analysis/get_tk_sample.py
@@ -1,0 +1,99 @@
+"""
+Take a sample of the TK job adverts to be used in the pipeline.
+
+Output is a dict of each tk file name and a list of the job ids
+within it which are included in the sample.
+e.g. {"historical/...0.json": ['6001f8701aeb4072a8eb0cca85535208', ...]}
+"""
+
+from skills_taxonomy_v2.getters.s3_data import (
+    load_s3_data,
+    get_s3_data_paths,
+    save_to_s3,
+)
+
+from argparse import ArgumentParser
+from collections import defaultdict
+import random
+import os
+import yaml
+
+from tqdm import tqdm
+import boto3
+
+from skills_taxonomy_v2 import BUCKET_NAME
+
+s3 = boto3.resource("s3")
+
+
+def parse_arguments(parser):
+
+    parser.add_argument(
+        "--config_path",
+        help="Path to config file",
+        default="skills_taxonomy_v2/config/tk_data_sample/2021.10.25.yaml",
+    )
+
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+
+    parser = ArgumentParser()
+    args = parse_arguments(parser)
+
+    with open(args.config_path, "r") as f:
+        config = yaml.load(f, Loader=yaml.FullLoader)
+
+    FLOW_ID = "get_tk_sample"
+    flow_config = config["flows"][FLOW_ID]
+    params = flow_config["params"]
+
+    tk_metadata_dir = params["tk_metadata_dir"]
+
+    # Get all the job ids in the job id:file location dictionary
+    # from tk metadata (outputted from "get_bulk_metadata.py")
+    tk_metadata_paths = get_s3_data_paths(
+        s3, BUCKET_NAME, tk_metadata_dir, file_types=["*.json"]
+    )
+
+    # There is some duplication in job id, so use unique set
+    job_ids = set()
+    for tk_metadata_path in tqdm(tk_metadata_paths):
+        file_dict = load_s3_data(s3, BUCKET_NAME, tk_metadata_path)
+        job_ids.update(set(file_dict.keys()))
+
+    # Take a random sample
+    random.seed(params["random_seed"])
+    job_ids_sample = random.sample(job_ids, params["sample_size"])
+
+    del job_ids
+
+    # It's quicker to query a set than a list
+    job_ids_sample_set = set(job_ids_sample)
+
+    # Output a dict of the job ids sampled from each file.
+    # The nuance is that multiple files may have the same job id,
+    # so only include the first one when iterating through the files
+    # randomly
+
+    sample_locs = defaultdict(list)
+    job_ids_seen = set()
+    random.seed(params["random_seed"])
+    random.shuffle(tk_metadata_paths)
+
+    for tk_metadata_path in tqdm(tk_metadata_paths):
+        file_dict = load_s3_data(s3, BUCKET_NAME, tk_metadata_path)
+        for job_id, file_name in file_dict.items():
+            if (job_id in job_ids_sample_set) and (job_id not in job_ids_seen):
+                sample_locs[file_name].append(job_id)
+                job_ids_seen.add(job_id)
+
+    print(sum([len(v) for v in sample_locs.values()]) == params["sample_size"])
+
+    save_to_s3(
+        s3,
+        BUCKET_NAME,
+        sample_locs,
+        os.path.join(params["output_dir"], "sample_file_locations.json"),
+    )


### PR DESCRIPTION
---

Fixing #68 
- find and save a sample of the text kernel data (`get_tk_sample.py`)
- update predict sentence class to be able to use data from a pre-found sample (rather than sampling within this script). Also works for old method too.
- update readmes

This samples 5 million job adverts randomly. Thus when the skill sentence predictions are outputted, although in sum there are more - each file contains less data. Previously 100 random files were selected and the first 10k job adverts were processed. Now there is data from 647 of these files, and a random selection from each (which is less that 10k).

## Timing
Each file goes through the same algorithm independently, and takes roughly 15-20minutes. These are the timings for each step of the algorithm for 1 data file out of 647:
```
2021-10-26 17:34:02,278 - __main__ - INFO - Loading data from inputs/data/textkernel-files/historical/2020/2020-03-11/jobs_2.110.jsonl.gz ...
2021-10-26 17:34:18,424 - __main__ - INFO - Splitting sentences ...
2021-10-26 17:39:30,769 - __main__ - INFO - Splitting sentences took 312.3075065612793 seconds
2021-10-26 17:39:30,795 - __main__ - INFO - Processing sentences took 312.3337023258209 seconds
2021-10-26 17:39:30,795 - __main__ - INFO - Transforming skill sentences ...
Getting embeddings for 168906 texts ...
.. with multiprocessing
2021-10-26 17:39:30,795 - sentence_transformers.SentenceTransformer - INFO - Start multi-process pool on devices: cuda:0
[nltk_data] Downloading package averaged_perceptron_tagger to
[nltk_data]     /home/ubuntu/nltk_data...
[nltk_data]   Package averaged_perceptron_tagger is already up-to-
[nltk_data]       date!
[nltk_data] Downloading package punkt to /home/ubuntu/nltk_data...
[nltk_data]   Package punkt is already up-to-date!
2021-10-26 17:39:33,602 - sentence_transformers.SentenceTransformer - INFO - Chunk data into packages of size 5000
Took 643.1803483963013 seconds
2021-10-26 17:53:31,097 - __main__ - INFO - Chunking up sentences ...
2021-10-26 17:53:31,248 - __main__ - INFO - Chunking up sentences into 169 chunks took 0.1508171558380127 seconds
2021-10-26 17:53:31,248 - __main__ - INFO - Predicting skill sentences ...
2021-10-26 17:54:07,619 - __main__ - INFO - Predicting on 168906 sentences took 36.37088871002197 seconds
2021-10-26 17:54:07,619 - __main__ - INFO - Combining data for output ...
2021-10-26 17:54:07,675 - __main__ - INFO - Combining output took 0.05558419227600098 seconds
2021-10-26 17:54:07,675 - __main__ - INFO - Saving data to outputs/sentence_classifier/data/skill_sentences/2021.10.26/textkernel-files/historical/2020/2020-03-11/jobs_2.110_2021.08.16.json ...
2021-10-26 17:54:08,017 - skills_taxonomy_v2.getters.s3_data - INFO - Saved to s3://skills-taxonomy-v2 + outputs/sentence_classifier/data/skill_sentences/2021.10.26/textkernel-files/historical/2020/2020-03-11/jobs_2.110_2021.08.16.json ...
```
9871 job adverts were in the "historical/2020/2020-03-11/jobs_2.110.jsonl.gz" file.

We would expect an average of 5000000/647 = 7728 of the sampled job adverts in each file. So this file seems to have a particularly large sample of job adverts in.

There will be different numbers of sentences in each job advert, but scaling that up it means that 20mins*647 = 9 days. or 20mins*(5000000/9871) = 7 days.

## Target areas for speeding up!

1. Around a half of the processing is spent transforming the sentences using the BERT model.

The biggest sticking point is in the transforming of the sentences using the pre-trained BERT model (even when using multiprocessing), i.e. in this function https://github.com/nestauk/skills-taxonomy-v2/blob/830be30e768c2c216ba371b62a845709b0108b30/skills_taxonomy_v2/pipeline/sentence_classifier/sentence_classifier.py#L76 . This is called in this PR [here](https://github.com/nestauk/skills-taxonomy-v2/pull/73/files#r737364618).

So could this step be done better in order to speed up that area of the pipeline?

2. Around a quarter of the processing is spent splitting the sentences.

The second biggest time lag is splitting the text up into sentences. This is done via the function [split_sentence](https://github.com/nestauk/skills-taxonomy-v2/blob/830be30e768c2c216ba371b62a845709b0108b30/skills_taxonomy_v2/pipeline/sentence_classifier/utils.py#L50) - in this PR this function is called [here](https://github.com/nestauk/skills-taxonomy-v2/pull/73/files#r737359285)

